### PR TITLE
Take into account PATHEXT on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         jdk: [8]
-        python: [3.7, 3.8, 3.9]
+        python: [3.8, 3.9, "3.10"]
     steps:
       - uses: actions/checkout@master
       - uses: coursier/cache-action@v6.3
@@ -28,7 +28,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Test
-        run: sbtn +test
+        run: sbt +test
         shell: bash
   publish:
     runs-on: ubuntu-20.04

--- a/src/main/scala/ai/kien/python/Python.scala
+++ b/src/main/scala/ai/kien/python/Python.scala
@@ -99,7 +99,7 @@ class Python private[python] (
     val l = for {
       elem <- path.split(pathSeparator).iterator
       elemPath = fs.getPath(elem)
-      ext  <- pathExts.iterator
+      ext <- pathExts.iterator
     } yield Files.exists(elemPath.resolve(exec + ext))
 
     l.contains(true)
@@ -192,13 +192,21 @@ object Python {
   private def executableCmd = "import sys;print(sys.executable)"
 
   private def ldversionCmd =
-    "import sys,sysconfig;print(sysconfig.get_python_version() + sys.abiflags)"
+    """import sys
+      |import sysconfig
+      |try:
+      |    abiflags = sys.abiflags
+      |except AttributeError:
+      |    abiflags = ''
+      |print(sysconfig.get_python_version() + abiflags)
+    """.stripMargin
 
-  private def libPathCmd = Seq(
-    "import sys",
-    "import os.path",
-    "from sysconfig import get_config_var",
-    "print(get_config_var('LIBPL') + ';')",
-    "print(os.path.join(sys.base_prefix, 'lib'))"
-  ).mkString(";")
+  private def libPathCmd =
+    """import sys
+      |import os.path
+      |from sysconfig import get_config_var
+      |libpl = get_config_var('LIBPL')
+      |libpl = libpl + ';' if libpl is not None else ''
+      |print(libpl + os.path.join(sys.base_prefix, 'lib'))
+    """.stripMargin
 }


### PR DESCRIPTION
This env var contains extensions of executable files, separated by ';' (so it looks like ".exe;.bat;…"). It should be taken into account when looking for executables in PATH on Windows.

My hope is that this should help for https://github.com/almond-sh/almond/pull/854.